### PR TITLE
feat(sass files): ajusta _typography.scss e remove _breadcrumb.scss e gitkeep

### DIFF
--- a/src/assets/sass/components/_breadcrumb.scss
+++ b/src/assets/sass/components/_breadcrumb.scss
@@ -1,7 +1,0 @@
-.breadcrumb {
-	&-item {
-		&.active {
-			font-weight: $font-weight-bold;
-		}
-	}
-}

--- a/src/assets/sass/frontend.scss
+++ b/src/assets/sass/frontend.scss
@@ -43,7 +43,6 @@
 @import "frontend/reboot";
 @import "frontend/typography";
 @import "components/animations";
-@import "components/breadcrumb";
 @import "components/card";
 @import "components/floating-labels";
 @import "components/fmd-header";
@@ -52,5 +51,6 @@
 @import "components/modal";
 @import "components/structure";
 @import "components/videos";
+@import "components/typography";
 @import "styles";
 

--- a/src/assets/sass/frontend/_typography.scss
+++ b/src/assets/sass/frontend/_typography.scss
@@ -6,65 +6,6 @@
 	}
 }
 
-.text-underline {
-	text-decoration: underline;
-}
-
-h1 {
-  font-size: 1.75rem;
-
-  @include media-breakpoint-up(lg) {
-    font-size: 2.5rem;
-  }
-}
-
-h2 {
-  font-size: 1.5rem;
-
-  @include media-breakpoint-up(lg) {
-    font-size: 2rem;
-  }
-}
-
-h3 {
-  font-size: 1.25rem;
-
-  @include media-breakpoint-up(lg) {
-    font-size: 1.5rem;
-  }
-}
-
-.display-3 {
-  font-size: 1rem;
-
-  @include media-breakpoint-up(lg) {
-    font-size: 1.125rem;
-  }
-}
-
-.banner {
-
-  &-title {
-
-    font-size: 1.75rem;
-    margin-bottom: 1.5rem;
-    line-height: 120%;
-
-    @include media-breakpoint-up(lg) {
-
-      font-size: 2.5rem;
-    }
-  }
-
-  &-description {
-
-    margin-bottom: 1.5rem;
-    font-size: .875rem;
-    line-height: 160%;
-    font-weight: $font-weight-normal;
-  }
-}
-
 .reset-text-transform {
 
   text-transform: initial !important;


### PR DESCRIPTION
Como frontend gostaria de deixar menos classes desnecessárias no _typography.scss. Remover _breadcrumb.scss pois o Angular permite criar folhas de estilo para componentes isolados e remover .gitkeep